### PR TITLE
Create long timer switch and functionality

### DIFF
--- a/src/components/PomoForm.less
+++ b/src/components/PomoForm.less
@@ -9,6 +9,11 @@
 
   .interval-timer {
     margin-bottom: 12px;
+    min-width: 320px;
+  }
+
+  .long-switch {
+    margin-bottom: 16px;
   }
 
   .pomo-count-note {

--- a/src/components/PomoForm.tsx
+++ b/src/components/PomoForm.tsx
@@ -1,23 +1,41 @@
 import './PomoForm.less';
 import { useState, useCallback } from 'react';
-import { Button, TextField } from '@mui/material';
-import { POMODORO_INITIAL_INTERVAL } from '../constants';
+import {
+  Button,
+  FormControlLabel,
+  FormHelperText,
+  Switch,
+  TextField,
+} from '@mui/material';
+import {
+  POMODORO_INITIAL_INTERVAL,
+  POMO_FORM_HELPER_COUNT,
+  POMO_FORM_HELPER_LONG_CYCLES,
+  POMO_FORM_LABEL_COUNT,
+  POMO_FORM_LABEL_LONG_CYCLES,
+} from '../constants';
 import { PomoFormProps } from '../constants/types';
 
 export default function PomoForm({ onSubmitForm }: PomoFormProps) {
   const [numberPomodoros, setNumberPomodoros] = useState(POMODORO_INITIAL_INTERVAL);
+  const [isLongPomoChecked, setIsLongPomoChecked] = useState(false);
 
   const setPomodoroIntervalsHandler = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     setNumberPomodoros(Number(event.currentTarget.value));
   }, []);
 
+  const changeLongPomoHandler = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setIsLongPomoChecked(event.target.checked);
+  }, []);
+
   const formSubmitHandler = useCallback(() => {
     onSubmitForm({
       intervals: numberPomodoros,
+      isLong: isLongPomoChecked,
     });
-  }, [numberPomodoros]);
+  }, [isLongPomoChecked, numberPomodoros]);
 
-  const willShowCountNote = numberPomodoros >= 4;
+  const countNote = numberPomodoros >= 4 ? POMO_FORM_HELPER_COUNT : '';
 
   return (
     <form
@@ -27,14 +45,22 @@ export default function PomoForm({ onSubmitForm }: PomoFormProps) {
       <h2 className="title">Pomodoro Timer</h2>
       <TextField
         classes={{ root: 'interval-timer' }}
-        label="Pomodoro Sessions"
+        helperText={countNote}
+        label={POMO_FORM_LABEL_COUNT}
         onChange={setPomodoroIntervalsHandler}
         type="number"
         value={numberPomodoros}
       />
-      {willShowCountNote && (
-        <p className="pomo-count-note">Session counts after 4 will include a long break timer.</p>
-      )}
+      <FormControlLabel
+        control={
+          <Switch
+            checked={isLongPomoChecked}
+            onChange={changeLongPomoHandler}
+          />
+        }
+        label={POMO_FORM_LABEL_LONG_CYCLES}
+      />
+      <FormHelperText classes={{ root: 'long-switch' }}>{POMO_FORM_HELPER_LONG_CYCLES}</FormHelperText>
       <Button variant="contained" type="submit">Start timer</Button>
     </form>
   );

--- a/src/components/PomodoroTimer.tsx
+++ b/src/components/PomodoroTimer.tsx
@@ -17,7 +17,8 @@ export default function PomodoroTimer() {
   }, []);
 
   const submitFormHandler = useCallback((formValues: PomodoroTimerFormHandlerProps) => {
-    const pomoQueueItems = generateQueueList(formValues.intervals);
+    const { intervals, isLong } = formValues;
+    const pomoQueueItems = generateQueueList(intervals, isLong);
     setQueueList(pomoQueueItems);
     timerStartHandler(pomoQueueItems[0]);
   }, [timerStartHandler]);

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,12 +11,19 @@ export const POMO_STATE_DESCRIPTION_BREAK = 'Get up and stretch, maybe grab some
 export const POMO_STATE_DESCRIPTION_BREAK_LONG = 'Step away for a bit, maybe grab a cup of tea or coffee';
 export const POMO_STATE_DESCRIPTION_FOCUS = 'Sit and breathe; you got this';
 
+export const POMO_FORM_LABEL_COUNT = 'Pomodoro sessions';
+export const POMO_FORM_LABEL_LONG_CYCLES = 'Use Long Pomodoro Cycles';
+export const POMO_FORM_HELPER_COUNT = 'Session counts after 4 will include a long break timer.';
+export const POMO_FORM_HELPER_LONG_CYCLES = 'A long cycle is 50 mins of focus followed by a 10 min break';
+
 // magic numbers
 export const POMODORO_INITIAL_INTERVAL = 4;
 
 export const POMODORO_TIMER_FOCUS = 25;
 export const POMODORO_TIMER_BREAK = 5;
 export const POMODORO_TIMER_BREAK_LONG = 15;
+
+export const POMODORO_TIMER_LONG_MULTIPLIER = 2;
 
 export const POMODORO_TIMER_HEIGHT = 292; // accounts for border size of parent
 

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -20,4 +20,5 @@ export interface PomoTimerProps {
 // Handler Props
 export interface PomodoroTimerFormHandlerProps {
   intervals: number,
+  isLong: boolean,
 }

--- a/src/utils/generateQueueList.ts
+++ b/src/utils/generateQueueList.ts
@@ -2,6 +2,7 @@ import {
   POMODORO_TIMER_BREAK,
   POMODORO_TIMER_BREAK_LONG,
   POMODORO_TIMER_FOCUS,
+  POMODORO_TIMER_LONG_MULTIPLIER,
   QUEUE_TYPE_BREAK,
   QUEUE_TYPE_BREAK_LONG,
   QUEUE_TYPE_FOCUS,
@@ -11,13 +12,13 @@ import { QueueItem } from '../constants/types';
 /**
  * Creates a queue list combined of the respective work/break periods
  * @param {number} intervals The number of working intervals
+ * @param {isLong} isLong If the intervals are long or doubled
  * @returns {QueueItems[]} Returns an array containing work and break intervals
  */
-export default function generateQueueList(intervals: number): QueueItem[] {
+export default function generateQueueList(intervals: number, isLong: boolean): QueueItem[] {
   return Array(intervals * 2).fill(undefined).map((_, index: number) => {
     let type = QUEUE_TYPE_FOCUS;
-    // work, break, work, break, work, break, work, long break,
-    // work, break, work, break, work, break, work, long break,
+    const multiplier = isLong ? POMODORO_TIMER_LONG_MULTIPLIER : 1;
     if (index % 2 !== 0) type = QUEUE_TYPE_BREAK;
     if ((index+1) % 8 === 0) type = QUEUE_TYPE_BREAK_LONG;
 
@@ -25,19 +26,19 @@ export default function generateQueueList(intervals: number): QueueItem[] {
       case QUEUE_TYPE_BREAK:
         return {
           type,
-          duration: POMODORO_TIMER_BREAK,
+          duration: POMODORO_TIMER_BREAK * multiplier,
         };
 
       case QUEUE_TYPE_BREAK_LONG:
         return {
           type,
-          duration: POMODORO_TIMER_BREAK_LONG,
+          duration: POMODORO_TIMER_BREAK_LONG * multiplier,
         };
 
       default:
         return {
           type,
-          duration: POMODORO_TIMER_FOCUS,
+          duration: POMODORO_TIMER_FOCUS * multiplier,
         };
     }
   });


### PR DESCRIPTION
Adds a switch for a "long timer" meaning to double the time that the timer runs for focus, break, and long break states. By request for folks that work longer than 25 minutes at a time.