### PR TITLE
Add Ongoing Timer to Page Title

### DIFF
--- a/src/components/PomoTimer.tsx
+++ b/src/components/PomoTimer.tsx
@@ -6,7 +6,6 @@ import { PomoTimerProps, QueueItem } from '../constants/types';
 import { minutesToSeconds } from '../utils/timerHelpers';
 import formatToTwoNumbers from '../utils/numberHelpers';
 import {
-  APP_TITLE,
   APP_TITLE_BREAK,
   APP_TITLE_BREAK_LONG,
   APP_TITLE_FOCUS,

--- a/src/components/PomoTimer.tsx
+++ b/src/components/PomoTimer.tsx
@@ -6,6 +6,10 @@ import { PomoTimerProps, QueueItem } from '../constants/types';
 import { minutesToSeconds } from '../utils/timerHelpers';
 import formatToTwoNumbers from '../utils/numberHelpers';
 import {
+  APP_TITLE,
+  APP_TITLE_BREAK,
+  APP_TITLE_BREAK_LONG,
+  APP_TITLE_FOCUS,
   MINUTES_IN_SECOND,
   POMODORO_TIMER_HEIGHT,
   POMO_STATE_DESCRIPTION_BREAK,
@@ -32,6 +36,10 @@ export default function PomoTimer({
   const [currentTimer, setCurrentTimer] = useState<QueueItem>(queue[0]);
   const [remainingQueue, setRemainingQueue] = useState<QueueItem[]>(queue.slice(1));
   const [countdownTime, setCountdownTime] = useState(minutesToSeconds(queue[0].duration));
+
+  const { type: countdownType, duration: countdownDuration } = currentTimer;
+  const minutes = Math.floor(countdownTime / MINUTES_IN_SECOND);
+  const seconds = formatToTwoNumbers(countdownTime - minutes * MINUTES_IN_SECOND);
 
   const soundEffectAudio = useMemo(() => new Audio(soundEffect), []);
 
@@ -70,17 +78,33 @@ export default function PomoTimer({
       onTimerStart(nextQueueItem);
     } else if (countdownTime === 3) {
       soundEffectAudio.play();
+    } else {
+      let appTitle = '';
+
+      switch(countdownType) {
+        case QUEUE_TYPE_BREAK:
+          appTitle = APP_TITLE_BREAK;
+          break;
+
+        case QUEUE_TYPE_BREAK_LONG:
+          appTitle = APP_TITLE_BREAK_LONG;
+          break;
+
+        case QUEUE_TYPE_FOCUS:
+        default:
+          appTitle = APP_TITLE_FOCUS;
+          break;
+      }
+
+      document.title = `${minutes}:${seconds} - ${appTitle}`;
     }
   }, [countdownTime, remainingQueue, soundEffectAudio]);
 
-  const { type, duration } = currentTimer;
-  const sandHeight = POMODORO_TIMER_HEIGHT * countdownTime / minutesToSeconds(duration);
-  const minutes = Math.floor(countdownTime / MINUTES_IN_SECOND);
-  const seconds = formatToTwoNumbers(countdownTime - minutes * MINUTES_IN_SECOND);
+  const sandHeight = POMODORO_TIMER_HEIGHT * countdownTime / minutesToSeconds(countdownDuration);
   let title = '';
   let descriptor = '';
 
-  switch(type) {
+  switch(countdownType) {
     case QUEUE_TYPE_BREAK:
       title = POMO_STATE_TITLE_BREAK;
       descriptor = POMO_STATE_DESCRIPTION_BREAK;

--- a/src/components/PomodoroTimer.tsx
+++ b/src/components/PomodoroTimer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import generateQueueList from '../utils/generateQueueList';
 import { PomodoroTimerFormHandlerProps, QueueItem } from '../constants/types';
+import { APP_TITLE } from '../constants';
 import PomoForm from './PomoForm';
 import PomoTimer from './PomoTimer';
 import './PomodoroTimer.less';
@@ -27,6 +28,7 @@ export default function PomodoroTimer() {
   const timerCompleteHandler = useCallback(() => {
     setQueueList([]);
     removeAllBodyStyles();
+    document.title = APP_TITLE;
   }, [removeAllBodyStyles]);
 
   const isFormShowing = !queueList.length;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -40,9 +40,9 @@ export const LOFI_GIRL_CREDIT = 'Provided by Lofi Girl';
 // magic numbers
 export const POMODORO_INITIAL_INTERVAL = 4;
 
-export const POMODORO_TIMER_FOCUS = 25;
-export const POMODORO_TIMER_BREAK = 5;
-export const POMODORO_TIMER_BREAK_LONG = 15;
+export const POMODORO_TIMER_FOCUS = 0.1;
+export const POMODORO_TIMER_BREAK = 0.1;
+export const POMODORO_TIMER_BREAK_LONG = 0.1;
 
 export const POMODORO_TIMER_LONG_MULTIPLIER = 2;
 
@@ -52,3 +52,8 @@ export const MINUTES_IN_SECOND = 60;
 
 // initial values
 export const POMO_FORM_DEFAULT_TASKS = [{ id: 'default', name: 'Make todo list', isComplete: true }];
+
+export const APP_TITLE = 'Pomodoro Timer';
+export const APP_TITLE_FOCUS = `Focus - ${APP_TITLE}`;
+export const APP_TITLE_BREAK = `Break - ${APP_TITLE}`;
+export const APP_TITLE_BREAK_LONG = `Long Break - ${APP_TITLE}`;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -40,9 +40,9 @@ export const LOFI_GIRL_CREDIT = 'Provided by Lofi Girl';
 // magic numbers
 export const POMODORO_INITIAL_INTERVAL = 4;
 
-export const POMODORO_TIMER_FOCUS = 0.1;
-export const POMODORO_TIMER_BREAK = 0.1;
-export const POMODORO_TIMER_BREAK_LONG = 0.1;
+export const POMODORO_TIMER_FOCUS = 25;
+export const POMODORO_TIMER_BREAK = 5;
+export const POMODORO_TIMER_BREAK_LONG = 15;
 
 export const POMODORO_TIMER_LONG_MULTIPLIER = 2;
 


### PR DESCRIPTION
More to help with at-a-glance information, I wanted to include the timer information into the page title. It more helps with viewing the information instead of staring at the timer or jumping to the page if you need the information.