### PR TITLE
Feature - Complete All Todos

### DIFF
--- a/src/app/rootReducer.ts
+++ b/src/app/rootReducer.ts
@@ -1,5 +1,6 @@
+import { combineSlices } from '@reduxjs/toolkit';
 import { default as todoListReducer } from '@/features/todolist/todolistSlice';
 
-export const rootReducer = {
-  todolist: todoListReducer,
-};
+export const rootReducer = combineSlices(
+  todoListReducer,
+);

--- a/src/features/buttons/StickyButtons.tsx
+++ b/src/features/buttons/StickyButtons.tsx
@@ -5,7 +5,7 @@ import { LOFI_PLAYER_TRACKS } from '@/common/constants/lofi-tracks';
 import { Song } from '@/common/types';
 import { createAudioLofiPlayer, getRandomSongIndex, usePrevious } from '@/common/utils';
 import { useAppDispatch } from '@/app/hooks';
-import { deleteCompleteTodos } from '@/features/todolist/todolistSlice';
+import { completeTodos, deleteCompleteTodos } from '@/features/todolist/todolistSlice';
 import {
   GITHUB_BUTTON_ARIA_LABEL,
   GITHUB_BUTTON_HREF,
@@ -95,6 +95,11 @@ export function StickyButtons() {
     setOptionsAnchorEl(null);
   }, [dispatch]);
 
+  const clickCompleteTodos = useCallback(() => {
+    dispatch(completeTodos());
+    setOptionsAnchorEl(null);
+  }, [dispatch]);
+
   const renderLofiPlayerTooltipTitle = useCallback(() => {
     switch (isPlaying) {
       case true:
@@ -146,7 +151,8 @@ export function StickyButtons() {
           anchorEl={optionsAnchorEl}
           onClose={closeMoreOptions}
         >
-          <MenuItem onClick={clickDeleteCheckedTodos}>Delete checked items</MenuItem>
+          <MenuItem onClick={clickDeleteCheckedTodos}>Delete completed items</MenuItem>
+          <MenuItem onClick={clickCompleteTodos}>Mark all items complete</MenuItem>
         </Menu>
       </div>
     </div>

--- a/src/features/todolist/redux/completeTodos.ts
+++ b/src/features/todolist/redux/completeTodos.ts
@@ -1,0 +1,10 @@
+import { TodosState } from '@/common/types';
+
+export function completeTodos(state: TodosState) {
+  state.todos = state.todos.map((todoItem) => {
+    return {
+      ...todoItem,
+      isComplete: true,
+    };
+  });
+}

--- a/src/features/todolist/redux/reducers.ts
+++ b/src/features/todolist/redux/reducers.ts
@@ -2,6 +2,7 @@ import { createTodo } from './createTodo';
 import { deleteTodo } from './deleteTodo';
 import { deleteCompleteTodos } from './deleteCompleteTodos';
 import { toggleTodo } from './toggleTodo';
+import { completeTodos } from './completeTodos';
 import { updateTodo } from './updateTodo';
 
 export default {
@@ -9,5 +10,6 @@ export default {
   deleteTodo,
   deleteCompleteTodos,
   toggleTodo,
+  completeTodos,
   updateTodo,
 };

--- a/src/features/todolist/todolistMiddleware.ts
+++ b/src/features/todolist/todolistMiddleware.ts
@@ -1,5 +1,6 @@
 import { createListenerMiddleware, isAnyOf } from '@reduxjs/toolkit';
 import {
+  completeTodos,
   createTodo,
   deleteCompleteTodos,
   deleteTodo,
@@ -11,7 +12,7 @@ import { RootState } from '@/app/store';
 
 const listenerMiddleware = createListenerMiddleware();
 listenerMiddleware.startListening({
-  matcher: isAnyOf(createTodo, deleteTodo, toggleTodo, updateTodo, deleteCompleteTodos),
+  matcher: isAnyOf(createTodo, deleteTodo, toggleTodo, updateTodo, deleteCompleteTodos, completeTodos),
   effect: (_action, { getState }) => {
     const { todolist: { todos }} = getState() as RootState;
     localStorage.setItem(STORAGE_KEY_TODO_LIST, JSON.stringify(todos));

--- a/src/features/todolist/todolistSlice.ts
+++ b/src/features/todolist/todolistSlice.ts
@@ -15,6 +15,7 @@ export const {
   deleteTodo,
   deleteCompleteTodos,
   toggleTodo,
+  completeTodos,
   updateTodo,
 } = slice.actions;
 

--- a/src/features/todolist/todolistSlice.ts
+++ b/src/features/todolist/todolistSlice.ts
@@ -3,7 +3,7 @@ import { initialState } from './redux/initialState';
 import { default as reduxReducers } from './redux/reducers';
 import { default as reduxExtraReducers } from './redux/extraReducers';
 
-const { actions, reducer } = createSlice({
+const slice = createSlice({
   name: 'todolist',
   initialState,
   reducers: reduxReducers,
@@ -16,6 +16,6 @@ export const {
   deleteCompleteTodos,
   toggleTodo,
   updateTodo,
-} = actions;
+} = slice.actions;
 
-export default reducer;
+export default slice;


### PR DESCRIPTION
As an extension of the previous PR that added the ability to remove all checked item, I figured this would be an easy addition in order to check all items that are in the store.

The PR adds a button that will mark all todos as complete.